### PR TITLE
Improve Tesseract OCR recognition quality

### DIFF
--- a/extension-demos/tesseract/www/index.html
+++ b/extension-demos/tesseract/www/index.html
@@ -9,17 +9,9 @@
         corePath: "http://localhost:6060/index.js",
       });
       function recognize(language) {
-
-        let canvas = document.createElement("canvas");
-        let context = canvas.getContext("2d");
         let image = document.getElementById("image");
-        
-        canvas.width = image.width;
-        canvas.height = image.height;
-        context.drawImage(image, 0, 0 );
-        let file = context.getImageData(0, 0, image.width, image.height);
 
-        Tesseract.recognize(file, {"lang": language}).then(data => {
+        Tesseract.recognize(image, {"lang": language}).then(data => {
           $notify("didRecognize", data.text);
         });
       }


### PR DESCRIPTION
When inputting the demo image from the [tesseract.js example](http://tesseract.projectnaptha.com), I found that the output (`data.text`) returned was inaccurate (e.g. it returned only two words despite the image containing full paragraph of text).

Upon consulting the tesseract.js docs, I found that `Tesseract.recognize()` supports any [`ImageLike`](https://github.com/naptha/tesseract.js/tree/master#imagelike) object as an input. When passing a reference to the `<img>` element directly, I found that the output was essentially perfect this time.

I believe that transferring the image data to a canvas must have resulted in a loss of quality (e.g. the canvas probably had a low default value for dpi). By passing a direct reference to the `<img>` element instead, any possible quality loss is avoided.